### PR TITLE
java core: Fix float fields with int defaults.

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Java/Util.hs
+++ b/compiler/src/Language/Bond/Codegen/Java/Util.hs
@@ -83,17 +83,14 @@ defaultValue java Field {fieldDefault = Nothing, ..} = implicitDefault fieldType
 
 defaultValue java Field {fieldDefault = (Just def), ..} = explicitDefault def
   where
-    explicitDefault (DefaultInteger x) = Just $ intLiteral fieldType x
+    explicitDefault (DefaultInteger x) = Just $ intLiteral x
       where
-        intLiteral BT_Int8 value = [lt|#{value}|]
-        intLiteral BT_Int16 value = [lt|#{value}|]
-        intLiteral BT_Int32 value = [lt|#{value}|]
-        intLiteral BT_Int64 value = [lt|#{value}L|]
-        intLiteral BT_UInt8 value = [lt|#{value}|]
-        intLiteral BT_UInt16 value = [lt|#{value}|]
-        intLiteral BT_UInt32 value = [lt|#{value}|]
-        intLiteral BT_UInt64 value = [lt|#{value}|]
-        intLiteral _ _ = error "Java:Int:defaultValue/floatLiteral: impossible happened."
+        intMax = 2147483647
+        intMin = -2147483648
+        intLiteral value =
+            if value > intMax || value < intMin
+            then [lt|#{value}L|]
+            else [lt|#{value}|]
     explicitDefault (DefaultFloat x) = Just $ floatLiteral fieldType x
       where
         floatLiteral BT_Float y = [lt|#{y}f|]


### PR DESCRIPTION
This is valid bond and apparently valid in all target languages. We
were falling through a match that believed integer literals should be
suffixed with nothing or L based on the type of the field, and did not
expect to be called for float/double fields.

Java has no problem initializing
  * a long with an int literal
  * a float/double with an int/long
but does require that integer literals end in L if they do not fit in
the range of int, unlike C#. This change makes us decide whether to
append the L based on the value of the default and ignores the type of
the field.